### PR TITLE
feat: add centralized async exception and error handlers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 # app/main.py
 from fastapi import FastAPI, Depends
 from fastapi.exceptions import RequestValidationError
-from starlette.exceptions import HTTPException as StarletteHTTPException
+from slowapi.errors import RateLimitExceeded
 from fastapi.openapi.docs import get_swagger_ui_html, get_redoc_html
 from fastapi.openapi.utils import get_openapi
 
@@ -40,7 +40,7 @@ app.middleware("http")(log_requests)
 # =======================================
 # EXCEPTION HANDLERS
 # =======================================
-app.add_exception_handler(StarletteHTTPException, handlers.rate_limit_handler)
+app.add_exception_handler(RateLimitExceeded, handlers.rate_limit_handler)
 app.add_exception_handler(RequestValidationError, handlers.validation_exception_handler)
 app.add_exception_handler(Exception, handlers.internal_server_error_handler)
 

--- a/app/utils/handlers.py
+++ b/app/utils/handlers.py
@@ -2,15 +2,18 @@
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
-from starlette.exceptions import HTTPException as StarletteHTTPException
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 
 from app.core.logging import log_rate_limit_exceeded, logger
 from app.utils.responses import standard_response
 
 
-async def rate_limit_handler(request: Request, exc: StarletteHTTPException):
+async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
     """429 Too Many Requests"""
-    log_rate_limit_exceeded(request)
+    ip = get_remote_address(request)
+    log_rate_limit_exceeded(request, ip=ip)
+
     return JSONResponse(
         content=standard_response(
             status="error",


### PR DESCRIPTION
- rate_limit_handler returns 429 with clear message and logs via log_rate_limit_exceeded
- validation_exception_handler returns 422 with sanitized Pydantic error details
- internal_server_error_handler returns 500 with user‑friendly message and logs exception
- All handlers use standard_response for consistent payload structure
- Responses wrapped in JSONResponse to set correct HTTP status codes
- Prepared for registration in main.py under EXCEPTION HANDLERS