### PR TITLE
feat: Add wallet balance and transaction endpoints

### DIFF
--- a/app/api/v1/routes/wallet.py
+++ b/app/api/v1/routes/wallet.py
@@ -8,9 +8,35 @@ from app.core.middleware.rate_limiter import limiter
 from app.core.utils.response import standard_response
 from app.api.dependencies import get_current_user, get_wallet_service
 from app.modules.wallet.service import WalletService
-from app.modules.wallet.schemas import TransactionRequest
+from app.modules.wallet.schemas import TransactionRequest, WalletBalanceResponse
 
 router = APIRouter()
+
+
+@router.get("/balance", status_code=status.HTTP_200_OK, response_model=WalletBalanceResponse)
+@limiter.limit("10/minute")
+async def get_wallet_balance(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    wallet_service: WalletService = Depends(get_wallet_service),
+) -> dict[str, Any]:
+    """
+    Get the wallet balance for the authenticated user.
+    """
+    return await wallet_service.get_balance(current_user)
+
+
+@router.get("/transactions", status_code=status.HTTP_200_OK)
+@limiter.limit("10/minute")
+async def get_wallet_transactions(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    wallet_service: WalletService = Depends(get_wallet_service),
+) -> list[dict[str, Any]]:
+    """
+    Get all transactions for the authenticated user.
+    """
+    return await wallet_service.get_transactions(current_user)
 
 
 @router.post("/deposit", status_code=status.HTTP_200_OK)

--- a/app/modules/wallet/schemas.py
+++ b/app/modules/wallet/schemas.py
@@ -13,3 +13,10 @@ class TransactionRequest(BaseModel):
     amount: PositiveFloat
     currency: Optional[Currency] = None
 
+
+class WalletBalanceResponse(BaseModel):
+    """Schema for wallet balance response."""
+    total_balance: float
+    locked_amount: float
+    available_balance: float
+

--- a/app/modules/wallet/service.py
+++ b/app/modules/wallet/service.py
@@ -76,6 +76,49 @@ class WalletService:
             }
         }
 
+    async def get_balance(self, current_user: User) -> dict[str, Any]:
+        """
+        Get the wallet balance for the current user.
+
+        Args:
+            current_user (User): The authenticated user.
+
+        Returns:
+            dict[str, Any]: A dictionary with wallet balance details.
+        """
+        wallet = await self.wallet_repo.get_wallet_by_user_id(current_user.id)
+        if not wallet:
+            raise CustomException.e404_not_found("Wallet not found. Please contact support.")
+
+        return {
+            "total_balance": float(wallet.total_balance),
+            "locked_amount": float(wallet.locked_amount),
+            "available_balance": wallet.available_balance,
+        }
+
+    async def get_transactions(self, current_user: User) -> list[dict[str, Any]]:
+        """
+        Get all transactions for the current user.
+
+        Args:
+            current_user (User): The authenticated user.
+
+        Returns:
+            list[dict[str, Any]]: A list of user's transactions.
+        """
+        transactions = await self.transaction_repo.get_user_transactions(current_user.id)
+        return [
+            {
+                "id": str(tx.id),
+                "amount": float(tx.amount),
+                "type": tx.type.value,
+                "status": tx.status.value,
+                "created_at": tx.created_at.isoformat(),
+                "executed_at": tx.executed_at.isoformat() if tx.executed_at else None,
+            }
+            for tx in transactions
+        ]
+
     async def deposit(
         self,
         transaction_request: TransactionRequest,


### PR DESCRIPTION
- Adds `GET /wallet/balance` and `GET /wallet/transactions` to the wallet API.
- The `GET /wallet/balance` endpoint returns the total, locked, and available balance for the authenticated user.
- The `GET /wallet/transactions` endpoint returns a list of all transactions for the authenticated user, ordered by creation date in descending order.
- New service methods in `WalletService` to handle the business logic.
- A new repository method to fetch user-specific transactions.
- A `WalletBalanceResponse` schema for the balance endpoint.